### PR TITLE
Update to OpenSeadragon 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>openseadragon</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <name>WebJar-OpenSeadragon</name>
     <description>WebJar for OpenSeadragon</description>
     <url>http://webjars.org</url>
 
     <properties>
         <!-- The upstream version of OpenSeadragon pulled by this project -->
-        <upstream.version>2.0.0</upstream.version>
+        <upstream.version>2.1.0</upstream.version>
         <!-- Path from which to grab the upstream package -->
         <upstream.url>https://github.com/openseadragon/openseadragon/releases/download/v${upstream.version}/</upstream.url>
         <!-- Destination into which to unpack the upstream package -->


### PR DESCRIPTION
There is a new version of OpenSeadragon ready to be packaged as a webjar.
